### PR TITLE
Add interactive monthly progress view and styled Excel export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 openpyxl
 streamlit
 matplotlib
+altair


### PR DESCRIPTION
## Summary
- Add Altair-based monthly progress chart with conditional coloring and table highlighting below threshold
- Highlight low avance% values across pivot, detail, and consolidated tables
- Export streamlined Excel with executive pivot sheet and embedded monthly progress chart

## Testing
- `python -m py_compile siaf_dashboard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9c0be4fb4832daea8b1a8355aa373